### PR TITLE
fix: jp/lesson-2-chapter-8

### DIFF
--- a/jp/2/8-feedandmultiply2.md
+++ b/jp/2/8-feedandmultiply2.md
@@ -97,7 +97,7 @@ function testDnaSplicing() public {
 
 1. まず、`_targetDna`が16桁であることを確認せよ。`_targetDna`を `_targetDna % dnaModulus`と同様にして最後の16桁だけ取り出せば良い。
 
-2. 次に`newDna`という名前の`uint`関数を宣言し、`myZombie`のDNAと`_targetDna`の平均値を設定せよ（上の例と同じだ）。
+2. 次に関数に`newDna`という名前の`uint`を宣言し、`myZombie`のDNAと`_targetDna`の平均値を設定せよ（上の例と同じだ）。
 
   > 注:`myZombie.name` と `myZombie.dna`を使って`myZombie`プロパティにアクセスできます。
 


### PR DESCRIPTION
before means "declare a function named 'newDna'"

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
