### PR TITLE
fix typo

### DIFF
--- a/en/14/03.md
+++ b/en/14/03.md
@@ -47,7 +47,7 @@ Interfaces are somehow similar to contracts, but they only declare functions. In
 * constructors,
 * or inherit from other contracts.
 
-You can think of an interface as of an ABI. Since they're used to allow different contracts to interact with each other, all functions must be `external`
+You can think of an interface as sort of an ABI. Since they're used to allow different contracts to interact with each other, all functions must be `external`
 
 Let's look at a simple example. Suppose there's a contract called `FastFood` that looks something like the following:
 


### PR DESCRIPTION
added 'sort' to 'of', so expression reads 'sort of'. otherwise could remove 'of'

- [ ] I did these translations myself and own copyright for them
- [ ] I didn't use a machine to do these translations
- [ ] I assign all copyright to Loom Network for these translations
