### PR TITLE
fix typos

### DIFF
--- a/en/14/06.md
+++ b/en/14/06.md
@@ -103,7 +103,7 @@ We've gone ahead and declared a `public` function called `callback`. It takes tw
 
 Next, let's fill in the body of the `callback` function.
 
-3. The function should first check to make sure `myRequests[id]` is `true`. Use a `require` statement to do this. The first parameter should be `myRequests[id]` and the second parameter should be "This request is not in my pending list."
+3. The function should first check to make sure `myRequests[_id]` is `true`. Use a `require` statement to do this. The first parameter should be `myRequests[_id]` and the second parameter should be "This request is not in my pending list."
 
 4. Next, save the new ETH price (the one that comes from the function parameters) into the `ethPrice` variable.
 


### PR DESCRIPTION
changed 'id' to '_id' to make it consistent with the function parameters where the text states the code should literally be 'id' but it should be '_id'. i.e. The function signature in the code has param name '_id'

- [ ] I did these translations myself and own copyright for them
- [ ] I didn't use a machine to do these translations
- [ ] I assign all copyright to Loom Network for these translations
