### PR TITLE
Fix keyword in note of lesson 11 chapter 6

### DIFF
--- a/en/11/06.md
+++ b/en/11/06.md
@@ -81,7 +81,7 @@ Then, `Truffle` will take care of everything. That's pretty sweet, isn't it?
 
 1. Below the line of code that initializes `alice` and `bob`, let's declare a variable named `contractInstance`. Don't assign it to anything.
 
-    >Note: We want `contractInstance` to be limited in scope to the block in which it's defined. Use `let` instead of `var`.
+    >Note: We want `contractInstance` to be limited in scope to the block in which it's defined. Use `let` instead of `const`.
 
 2. Next, copy/paste the snippet from above for defining the `beforeEach()` function.
 

--- a/fa/11/06.md
+++ b/fa/11/06.md
@@ -81,7 +81,7 @@ Then, `Truffle` will take care of everything. That's pretty sweet, isn't it?
 
 1. Below the line of code that initializes `alice` and `bob`, let's declare a variable named `contractInstance`. Don't assign it to anything.
 
-    >Note: We want `contractInstance` to be limited in scope to the block in which it's defined. Use `let` instead of `var`.
+    >Note: We want `contractInstance` to be limited in scope to the block in which it's defined. Use `let` instead of `const`.
 
 2. Next, copy/paste the snippet from above for defining the `beforeEach()` function.
 

--- a/zh/11/06.md
+++ b/zh/11/06.md
@@ -81,7 +81,7 @@ beforeEach(async () => {
 
 1.  在初始化 `alice` 和 `bob` 的代码行下面，让我们来声明一个名为 `contractInstance` 的变量。不要把它分配给任何东西。
 
-    >注意：我们想要 `contractInstance` 的作用域仅限于定义它的块。使用 `let` 代替 `var`。
+    >注意：我们想要 `contractInstance` 的作用域仅限于定义它的块。使用 `let` 代替 `const`。
 
 2.  接下来，复制/粘贴上面的代码片段，以定义 `beforeEach()` 函数。
 


### PR DESCRIPTION
- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations

Change the keyword from `var` to `const` in the note of lesson 11 chapter 6. It says :
```
Note: We want contractInstance to be limited in scope to the block in which it's defined. Use let instead of var.
```
But we're using `const`, not `var`, so the correct note should be :
```
Note: We want contractInstance to be limited in scope to the block in which it's defined. Use let instead of var.
```
