### PR TITLE
Fix misspellings of OpenZeppelin

### DIFF
--- a/en/14/04.md
+++ b/en/14/04.md
@@ -54,7 +54,7 @@ Here's the solution: you must use something called a `modifier`. A modifier is a
 
 So, fixing this security hole requires you to follow the following steps:
 
-* Import the content of the OpenZepellin's `Ownable` smart contract. We've covered OpenZepellin in our previous lessons, just go back and refresh your memory if need be.
+* Import the content of the OpenZeppelin's `Ownable` smart contract. We've covered OpenZeppelin in our previous lessons, just go back and refresh your memory if need be.
 * Make the contract inherit from `Ownable`.
 * Change the definition of the `setOracleInstanceAddress` function so that it uses the `onlyOwner` modifier.
 


### PR DESCRIPTION
There were two instances where OpenZeppelin was misspelled, so I corrected them.

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
