### PR TITLE
[JP] Fix duplicate object key "lessonMenu.getReward"

### DIFF
--- a/jp/index.json
+++ b/jp/index.json
@@ -20,12 +20,11 @@
         "readOnly": "閲覧のみ"
     },
     "lessonMenu": {
-        "getReward": "Rewards",
+        "getReward": "賞品",
         "pageTitle": "@:base.name | @:base.tagLine",
         "itemLabel": "レッスン {lessonNum}: {title}",
         "signIn": "サインインをすれば進捗をロード",
-        "progressLoaded": "進捗がロードされました",
-        "getReward": "賞品"
+        "progressLoaded": "進捗がロードされました"
     },
     "overview": {
         "pageTitle": "@:base.name {lesson} | @:base.tagLine",


### PR DESCRIPTION
- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations

I found a duplicate object key and fixed it.
There were two `getReward` key in `lessonMenu` in `jp/index.json`

