### PR TITLE
[JP] lesson6 chapter7: Translate more natural

### DIFF
--- a/jp/6/07.md
+++ b/jp/6/07.md
@@ -612,7 +612,7 @@ function createRandomZombie(name) {
 
   `feedOnKitty`を呼び出すロジックはほとんど同じだ。関数を呼び出すトランザクションを送信し、トランザクションがうまくいくと新たなゾンビが生成されるから、そのあとそれをUIに表示し直したい。
 
-  そのすぐ下に`createRandomZombie`のコピーを作成するが、以下の変更をするように:
+  `createRandomZombie`のコピーをその真下に作成せよ。ただし、以下の変更をするように:
 
   a) ２番目の関数`feedOnKitty`を呼び出せ。これは`zombieId`と`kittyId`の２つの引数を受け取る。
 


### PR DESCRIPTION
### Original English text
Make a copy of `createRandomZombie` right below it, but make the following changes:

### Japanese text
- As is: そのすぐ下に `createRandomZombie` のコピーを作成するが、以下の変更をするように:

The above Japanese text did not make sense to me, so I translated it as follows

- To be: `createRandomZombie`のコピーをその真下に作成せよ。ただし、以下の変更をするように:



- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
