### PR TITLE
Fix typo in events.md for all languages

### DIFF
--- a/de/1/events.md
+++ b/de/1/events.md
@@ -71,7 +71,7 @@ Example:
 
 Your app front-end could then listen for the event. A JavaScript implementation would look something like:
 
-    YourContract.IntegersAdded(function(error, result) { 
+    YourContract.IntegersAdded(function(error, result)) { 
       // do something with result
     }
     

--- a/en/1/events.md
+++ b/en/1/events.md
@@ -94,7 +94,7 @@ function add(uint _x, uint _y) public returns (uint) {
 Your app front-end could then listen for the event. A JavaScript implementation would look something like:
 
 ```
-YourContract.IntegersAdded(function(error, result) {
+YourContract.IntegersAdded(function(error, result)) {
   // do something with result
 })
 ```

--- a/es/1/events.md
+++ b/es/1/events.md
@@ -93,7 +93,7 @@ function add(uint _x, uint _y) public {
 La aplicación con la interfaz de usuario podría entonces estar escuchando el evento. Una implementación en JavaScript sería así:
 
 ```
-YourContract.IntegersAdded(function(error, result) {
+YourContract.IntegersAdded(function(error, result)) {
   // hacer algo con `result`
 }
 ```

--- a/fa/1/events.md
+++ b/fa/1/events.md
@@ -96,7 +96,7 @@ function add(uint _x, uint _y) public {
 فرانت اپ شما منتظر رویداد می‌مونه. پیاده‌سازی جاوااسکریپتش یه چیزی شبیه این می‌شه:
 </div>
 ```
-YourContract.IntegersAdded(function(error, result) { 
+YourContract.IntegersAdded(function(error, result)) { 
   // do something with result
 }
 ```

--- a/fr/1/events.md
+++ b/fr/1/events.md
@@ -94,7 +94,7 @@ function add(uint _x, uint _y) public {
 Votre application frontale pourrait alors être en attente de l'évènement. Voici un exemple d'implémentation JavaScript :
 
 ```
-YourContract.IntegersAdded(function(error, result) {
+YourContract.IntegersAdded(function(error, result)) {
   // faire quelque chose avec le résultat
 })
 ```

--- a/it/1/events.md
+++ b/it/1/events.md
@@ -94,7 +94,7 @@ function add(uint _x, uint _y) public {
 Il front-end dell'app potrebbe quindi ascoltare l'evento. Un'implementazione JavaScript sarebbe simile a:
 
 ```
-YourContract.IntegersAdded(function(error, result) { 
+YourContract.IntegersAdded(function(error, result)) { 
   // fare qualcosa con il risultato
 }
 ```

--- a/jp/1/events.md
+++ b/jp/1/events.md
@@ -94,7 +94,7 @@ function add(uint _x, uint _y) public {
 アプリのフロントエンドをリッスン（接続待ち）状態にできる。JavaScriptで実装すると次のように書けるのだ：
 
 ```
-YourContract.IntegersAdded(function(error, result) { 
+YourContract.IntegersAdded(function(error, result)) { 
   // 結果について何らかの処理をする
 }
 ```

--- a/ko/1/events.md
+++ b/ko/1/events.md
@@ -94,7 +94,7 @@ function add(uint _x, uint _y) public returns (uint) {
 그러면 자네 앱의 사용자 단은 해당 이벤트가 일어나는지 귀를 기울이지. 자바스크립트로 이를 구현하면 다음과 같네:
 
 ```
-YourContract.IntegersAdded(function(error, result) {
+YourContract.IntegersAdded(function(error, result)) {
   // 결과와 관련된 행동을 취한다
 }
 ```

--- a/no/1/events.md
+++ b/no/1/events.md
@@ -94,7 +94,7 @@ function add(uint _x, uint _y) public {
 Appen din, på front-end siden, kan lytte etter eventet. En JavaScript implementasjon vil se slik ut: 
 
 ```
-YourContract.IntegersAdded(function(error, result) { 
+YourContract.IntegersAdded(function(error, result)) { 
   // Gjør noe med resultatet
 }
 ```

--- a/pl/1/events.md
+++ b/pl/1/events.md
@@ -94,7 +94,7 @@ function add(uint _x, uint _y) public {
 Twoja aplikacja frontowa może nasłuchiwać na zdarzenia. JavaScript-owa implementacja powinna wyglądać następująco: 
 
 ```
-YourContract.IntegersAdded(function(error, result) { 
+YourContract.IntegersAdded(function(error, result)) { 
   // wywałaj logikę tutaj
 }
 ```

--- a/pt/1/events.md
+++ b/pt/1/events.md
@@ -94,7 +94,7 @@ function add(uint _x, uint _y) public {
 O seu aplicativo frontend poderá então ouvir o evento. Uma implementação em JavaScript ficaria assim:
 
 ```
-YourContract.IntegersAdded(function(error, result) {
+YourContract.IntegersAdded(function(error, result)) {
   // Faça algo com o resultado
 }
 ```

--- a/ru/1/events.md
+++ b/ru/1/events.md
@@ -94,7 +94,7 @@ function add(uint _x, uint _y) public {
 Теперь внешний интерфейс приложения сможет услышать событие. Примерно так будет выглядеть выполнение JavaScript:
 
 ```
-YourContract.IntegersAdded(function(error, result) { 
+YourContract.IntegersAdded(function(error, result)) { 
   // Воспользуйся результатом
 }
 ```

--- a/sk/1/events.md
+++ b/sk/1/events.md
@@ -94,7 +94,7 @@ function add(uint _x, uint _y) public {
 Front end tvojej aplikácie môže sledovať vyvolanie tejto udalosti. Javascriptová implementácia by vyzerala zhruba takto:
 
 ```
-YourContract.IntegersAdded(function(error, result) { 
+YourContract.IntegersAdded(function(error, result)) { 
   // nejaká reakcia na zachytenú eventu
 }
 ```

--- a/th/1/events.md
+++ b/th/1/events.md
@@ -94,7 +94,7 @@ function add(uint _x, uint _y) public {
 ด้านหน้าแอพพลิเคชั่นของคุณในตอนนี้ก็จะสามารถรับฟังอีเว้นท์ที่จะเกิดได้แล้ว ส่วนใน JavaScript การเขียนโค้ดจะหน้าตาดังนี้ :
 
 ```
-YourContract.IntegersAdded(function(error, result) { 
+YourContract.IntegersAdded(function(error, result)) { 
   // ทำบางอย่างกับ result
 }
 ```

--- a/tr/1/events.md
+++ b/tr/1/events.md
@@ -94,7 +94,7 @@ function add(uint _x, uint _y) public {
 Uygulamanızın başlangıç aşaması daha sonra etkinliği dinleyebilir. Bir JavaScript uygulaması şöyle görünür: 
 
 ```
-YourContract.IntegersAdded(function(error, result) { 
+YourContract.IntegersAdded(function(error, result)) { 
   // sonuç ile birşey yap
 }
 ```

--- a/zh/1/events.md
+++ b/zh/1/events.md
@@ -94,7 +94,7 @@ function add(uint _x, uint _y) public {
 你的 app 前端可以监听这个事件。JavaScript 实现如下:
 
 ```
-YourContract.IntegersAdded(function(error, result) { 
+YourContract.IntegersAdded(function(error, result)) { 
   // 干些事
 }
 ```


### PR DESCRIPTION
Correcting javascript function declaration.
Fix for issue #723 

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
