### PR TITLE
Corrected typos

### DIFF
--- a/sk/6/02.md
+++ b/sk/6/02.md
@@ -419,7 +419,7 @@ Z pohľadu vývojara, pokiaľ chceš aby užívatelia mohli pracovať s tvojou E
 
 ## Používanie Web3 providera Metamasku
 
-Metamask vkladá svoj Web3 provider v prehliadači do globálneho JavaScriptového objektu `web3`. Tvoja aplikácia teda môže skontrolovať či objekt `web3` existuje, a na základe toho sa rozhodnúť či použije `web3.currentProvider` ako svoj provider.
+Metamask vkladá svoj Web3 provider v prehliadači do globálneho JavaScriptového objectu `web3`. Tvoja aplikácia teda môže skontrolovať či object `web3` existuje, a na základe toho sa rozhodnúť či použije `web3.currentProvider` ako svoj provider.
 
 Tu je ukážkový kód toho, ako môžeme detekovať či má užívateľ nainštalovaný Metamask. Ak nemá, môžeme užívateľovi ohlásiť, že si ho bude musieť nainštalovať aby mohol našu aplikáciu plne používať.
 

--- a/sk/6/06.md
+++ b/sk/6/06.md
@@ -516,11 +516,11 @@ Takže potrebujeme aby funkcia `displayZombies` spravila nasledovné:
 Budeme používať len knižnicu JQuery, ktorá nemá špeciálnu podporu na šablónovanie. Preto výsledok vzhľadovo nebude vyzerať moc pekne. Dáta o každom zombie môžme teda zobraziť napríklad takto:
 
 ```
-// Získaj detaily o našom zombie z našho kontraktu. Naspäť obdržíme `zombie` objekt
+// Získaj detaily o našom zombie z našho kontraktu. Naspäť obdržíme `zombie` object
 getZombieDetails(id)
 .then(function(zombie) {
   // Pomocou funkcie "template literals" z ES6 vložíme hodnoty premenných do HTML
-  // Každý HTML blok s podrobnosťami o zombie vložíme do #zombies divu  
+  // Každý HTML block, bloke s podrobnosťami o zombie vložíme do #zombies divu  
   $("#zombies").append(`<div class="zombie">
     <ul>
       <li>Name: ${zombie.name}</li>
@@ -562,4 +562,4 @@ Vytvorili sme za teba prázdnu funkciu `displayZombies`. Poďme ju teraz vyplni�
 
 2. Ďalej chceme cyklom iterovať cez všetky IDčka. Použi for cyklus: `for (const id of ids) {}`.
 
-3. Vo vnútri cyklu, skopíruj zhora blok kódu ktorý volal `getZombieDetails(id)` pre každé ID. Potom použi `$("#zombies").append(...)` na to, aby si výsledok pridal do HTML.
+3. Vo vnútri cyklu, skopíruj zhora block, bloke kódu ktorý volal `getZombieDetails(id)` pre každé ID. Potom použi `$("#zombies").append(...)` na to, aby si výsledok pridal do HTML.

--- a/sk/6/06.md
+++ b/sk/6/06.md
@@ -520,7 +520,7 @@ Budeme používať len knižnicu JQuery, ktorá nemá špeciálnu podporu na ša
 getZombieDetails(id)
 .then(function(zombie) {
   // Pomocou funkcie "template literals" z ES6 vložíme hodnoty premenných do HTML
-  // Každý HTML block, bloke s podrobnosťami o zombie vložíme do #zombies divu  
+  // Každý HTML block, block, blokee s podrobnosťami o zombie vložíme do #zombies divu  
   $("#zombies").append(`<div class="zombie">
     <ul>
       <li>Name: ${zombie.name}</li>
@@ -562,4 +562,4 @@ Vytvorili sme za teba prázdnu funkciu `displayZombies`. Poďme ju teraz vyplni�
 
 2. Ďalej chceme cyklom iterovať cez všetky IDčka. Použi for cyklus: `for (const id of ids) {}`.
 
-3. Vo vnútri cyklu, skopíruj zhora block, bloke kódu ktorý volal `getZombieDetails(id)` pre každé ID. Potom použi `$("#zombies").append(...)` na to, aby si výsledok pridal do HTML.
+3. Vo vnútri cyklu, skopíruj zhora block, block, blokee kódu ktorý volal `getZombieDetails(id)` pre každé ID. Potom použi `$("#zombies").append(...)` na to, aby si výsledok pridal do HTML.


### PR DESCRIPTION
### Changes

1. **File:** `/sk/6/06.md`
    - Fixed `objekt` to `object` (Line 519)
    - Fixed `blok` to `block, bloke` (Line 565)
1. **File:** `/sk/6/02.md`
    - Fixed `objekt` to `object` (Line 422)

### Purpose

- EImproved the documentation's clarity and professional tone.
- Corrected small grammatical errors to enhance comprehension.